### PR TITLE
fix(T-080): breathe spinner vertical alignment

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -875,16 +875,23 @@ function Lightbox({
   )
 }
 
-// T-079 F6: breathe spinner — inline braille glyph driven by a frame index
-// passed in from App. Tabular-nums + fixed width prevents jitter as glyphs
-// of slightly different visual weight cycle. font-mono so the braille
-// codepoints render with consistent spacing across browsers.
+// T-079 F6 + T-080 fix: breathe spinner — inline braille glyph driven by a
+// frame index passed in from App. T-080: braille codepoints have visually
+// uneven vertical centroids inside their cell (⠀/⠂/⠌ sit low, ⡑ spans
+// full height), so plain `align-middle` (which aligns the *baseline* of the
+// glyph cell) made the spinner appear to hop above/below the adjacent sans
+// text "正在锻造 X%". Fix: wrap the glyph in an inline-flex container with
+// items-center + leading-none + a fixed 1em line-height box so the braille
+// cell is centered inside its own line-box, then the wrapper itself docks
+// to the surrounding text via items-center on the parent <p>'s vertical
+// rhythm. tabular-nums + width:1ch keeps row width stable as glyph weights
+// cycle.
 function BreatheSpinner({ frame }: { frame: number }) {
   return (
     <span
       aria-hidden="true"
-      className="inline-block mr-1.5 align-middle font-mono tabular-nums text-warm-700 dark:text-warm-400"
-      style={{ width: '1ch' }}
+      className="inline-flex items-center justify-center mr-1.5 align-middle font-mono tabular-nums leading-none text-warm-700 dark:text-warm-400"
+      style={{ width: '1ch', height: '1em', lineHeight: '1em' }}
     >
       {BREATHE_FRAMES[frame % BREATHE_FRAMES.length]}
     </span>


### PR DESCRIPTION
## T-080 hotfix · breathe spinner vertical alignment

Dale 22:57 报：进度条左侧 BreatheSpinner 视觉重心偏下，与右侧文字 "正在锻造 X%" 不在一条水平线上。

### 根因
- Braille codepoint 字形点位在 cell 内分布不均（`⠀`/`⠂`/`⠌` 偏下半，`⡑` 跨上下），视觉重心**动态变化**
- 用 `align-middle` + `inline-block` 包裹，`align-middle` 走 **baseline 对齐**，与相邻 sans 字体不匹配 → 看起来 spinner 在文字基线下方跳

### 修法（Cindy 推荐 A）
`BreatheSpinner` 容器：`inline-block` → `inline-flex items-center justify-center` + `leading-none` + 显式 `lineHeight: '1em', height: '1em'` inline style。让 braille glyph 在自己的 line-box 内居中，外层 `align-middle` dock 到父 `<p>` 行高。

**不改父 `<p>`**。不影响其他文字。修改面 = 1 个 component className 行 + inline style。

### 基于
PR #3 已 merge，本 PR 直接基于 main。

### Verification
- `npm run build` (tsc + vite) clean
- Staging 视觉验收: 进度 50% 时 spinner cell 中心 与 "50%" 文字 x-height 中心 在同一水平线（±1px tolerance for braille glyph 内在 centroid 抖动 — 这是字体本身的事，不是 CSS bug）

### Rollback
git revert. CSS-only 改动无数据风险。

cc <@1471045911353229394> review focus: `align-middle` + `inline-flex items-center` 同时存在是不是 redundant？我留 align-middle 是因为外层 `<p>` 还在走 inline 布局，担心去了之后 baseline drop。你判断
