### PR TITLE
feat(T-097): image model wan2.7 → qwen-image-2.0-pro

### DIFF
--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -81,7 +81,7 @@ interface SSEWriter {
 
 const DAILY_LIMIT = 5;
 const KIMI_MODEL = "qwen3.6-max-preview";
-const DASHSCOPE_MODEL = "wan2.7-image-pro";
+const DASHSCOPE_MODEL = "qwen-image-2.0-pro";
 const DASHSCOPE_SUBMIT_URL =
   "https://dashscope.aliyuncs.com/api/v1/services/aigc/multimodal-generation/generation";
 const KIMI_API_URL =


### PR DESCRIPTION
## T-097 / Issue #9

Single-line const swap: `worker/src/index.ts` L84 `wan2.7-image-pro` → `qwen-image-2.0-pro`.

### Diff
```diff
-const DASHSCOPE_MODEL = "wan2.7-image-pro";
+const DASHSCOPE_MODEL = "qwen-image-2.0-pro";
```

### Unchanged
- KIMI_MODEL = `qwen3.6-max-preview` (prompt rewriter)
- `enable_thinking: true` on rewriter (L383)
- assemblePrompt, size `1320*2868`, prompt_extend, rate-limit / turnstile / origin allow-list

### Local checks
- `tsc --noEmit` clean

### Acceptance (per issue)
- [ ] /api/generate returns qwen-image-2.0-pro output
- [ ] 4-master smoke (yoshitoshi/utamaro/hokusai/kuniyoshi) on prod ukiyo.weweekly.online passes Dale eyeball check
- [ ] No regression on rate-limit / turnstile / origin paths

Refs: T-097
Closes #9
