### PR TITLE
fix(T-099): correct meta description + worker package name

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,7 +5,7 @@
     <link rel="icon" type="image/png" href="/favicon.png" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Ukiyo-e — 浮世绘壁纸生成器</title>
-    <meta name="description" content="输入一句描述，生成两张 macOS 风格轻拟物 App Icon" />
+    <meta name="description" content="输入一句场景，生成日式浮世绘风格手机壁纸 — 月冈芳年 / 喜多川歌麿 / 葛饰北斋 / 歌川国芳 四大风格可选" />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@300;400;500;600;700&display=swap" rel="stylesheet" />

--- a/worker/package.json
+++ b/worker/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "icon-forge-worker",
+  "name": "ukiyo-e-worker",
   "version": "1.0.0",
   "private": true,
   "scripts": {


### PR DESCRIPTION
## T-099 / Issue #13

Fix index.html meta description leftover from icon-forge fork.

### Changes (2 lines)
**1. `index.html` L8** — meta description:
```diff
-<meta name="description" content="输入一句描述，生成两张 macOS 风格轻拟物 App Icon" />
+<meta name="description" content="输入一句场景，生成日式浮世绘风格手机壁纸 — 月冈芳年 / 喜多川歌麿 / 葛饰北斋 / 歌川国芳 四大风格可选" />
```

**2. `worker/package.json` L2** — package name:
```diff
-"name": "icon-forge-worker",
+"name": "ukiyo-e-worker",
```

### Grep audit (per acceptance)
其他 `macOS` / `App Icon` / `icon-forge` 残留全审了一遍：

| 文件 | 行 | 类型 | 处理 |
|------|----|------|------|
| `index.html:8` | meta description | 用户可见 | ✅ 改了 |
| `worker/package.json:2` | package name | 包元数据 | ✅ 改了 |
| `CHANGELOG.md:31` | "forked from icon-forge architecture" | 历史 credit | ⏭ 保留（forked-from 归属说明）|
| `worker/src/index.ts:178,373` | T-098 设计注释 "adopted icon-forge prompt engine pattern" | code comment | ⏭ 保留（说明设计师承）|

### Acceptance
- [x] `index.html` L8 meta description 改对
- [x] grep 审过其他位置，区分用户可见 vs 历史 credit
- [ ] deploy 后 `view-source:https://ukiyo.weweekly.online/` 验证

Refs: T-099
Closes #13
