### PR TITLE
ci: add typecheck + vite build workflow (SPEC-206 / T-317)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,20 @@
+name: ci
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "npm"
+      - run: npm ci
+      - run: npx tsc --noEmit
+      - run: npm run build


### PR DESCRIPTION
Adds minimal CI for typecheck + vite build on PR/push to main.

Spec: SPEC-206 / T-317

## What
- `.github/workflows/ci.yml`: setup Node 20, `npm ci`, `npx tsc --noEmit`, `npm run build`

## Why
Currently zero status checks on PRs. Catching type errors / build breaks here is faster than via CF Pages build minutes.

## Pairs with
Cindy will be cutting this repo over to CF Pages git-source integration (SPEC-206 main deliverable). Once that lands, CF Pages publishes its own check too — we keep both signals.

## Out of scope
- ESLint (no eslint config in repo yet)
- Worker-side CI

Closes part of SPEC-206 / T-317.