### PR TITLE
feat(ukiyo-e): upgrade prompt LLM to qwen3.7-max

### DIFF
--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -83,7 +83,7 @@ interface SSEWriter {
 // --- Constants ---
 
 const DAILY_LIMIT = 5;
-const KIMI_MODEL = "qwen3.6-max-preview";
+const KIMI_MODEL = "qwen3.7-max"; // SPEC-235 followup: prompt LLM 升 qwen3.7-max(生图模型 qwen-image-2.0-pro 不变)
 const DASHSCOPE_MODEL = "qwen-image-2.0-pro";
 // SPEC-163: endpoints 全部走 api-llm.openclawd.co gateway。
 // Gateway 内部透传到 dashscope，上游响应 schema 不变；解析逻辑 0 修改。


### PR DESCRIPTION
Parallels icon-forge PR #20. KIMI_MODEL (prompt LLM, 变量名历史遗留): qwen3.6-max-preview → qwen3.7-max. 生图模型 qwen-image-2.0-pro 不变。

Offline bench (icon-forge 同 prompt 风格): 2.6x faster + 更具象 metaphor + 同 schema 通过率。Dale 视觉验证 4 张 icon 已通过。