### PR TITLE
feat(worker): SPEC-285 迁移#2 ukiyo-e 标注 x-llm-usecase

### DIFF
--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -500,6 +500,8 @@ export async function synthesizePrompt(
       headers: {
         "Content-Type": "application/json",
         Authorization: `Bearer ${apiKey}`,
+        // SPEC-285 迁移#2：prompt 合成场景 usecase（网关自动发现 + 允许 dashboard 热切，不设 override 时仍用 body.model）
+        "x-llm-usecase": "prompt-gen",
       },
       body: JSON.stringify(requestBody),
     });
@@ -591,6 +593,8 @@ export async function generateIcon(
       headers: {
         "Content-Type": "application/json",
         Authorization: `Bearer ${apiKey}`,
+        // SPEC-285 迁移#2：浮世绘图像生成场景 usecase
+        "x-llm-usecase": "image-gen",
       },
       body: JSON.stringify({
         model: DASHSCOPE_MODEL,

--- a/worker/test/llm-gateway.test.ts
+++ b/worker/test/llm-gateway.test.ts
@@ -81,6 +81,8 @@ describe("SPEC-163 LLM gateway: URL + auth invariants", () => {
     const [url, init] = fetchMock.mock.calls[0];
     expect(url).toBe(`${GATEWAY}${CHAT_PATH}`);
     expect(init.headers.Authorization).toBe(`Bearer ${TOKEN}`);
+    // SPEC-285 迁移#2：prompt 合成带 x-llm-usecase 供网关发现场景
+    expect(init.headers["x-llm-usecase"]).toBe("prompt-gen");
     expect(init.method).toBe("POST");
   });
 
@@ -96,6 +98,8 @@ describe("SPEC-163 LLM gateway: URL + auth invariants", () => {
     const [url, init] = fetchMock.mock.calls[0];
     expect(url).toBe(`${GATEWAY}${IMAGE_PATH}`);
     expect(init.headers.Authorization).toBe(`Bearer ${TOKEN}`);
+    // SPEC-285 迁移#2：图像生成带 x-llm-usecase
+    expect(init.headers["x-llm-usecase"]).toBe("image-gen");
   });
 });
 


### PR DESCRIPTION
## T-486 / SPEC-285 业务迁移#2

照 T-485 (icon-forge#21) 模式：ukiyo-e worker 所有走 api-llm gateway 的 LLM 调用加 `x-llm-usecase` header，让网关自动发现场景 → routes 页 ukiyo-e 分组下自动出现各 usecase 行。

### 调用点 (worker/src/index.ts)
- `synthesizePrompt` → `/v1/chat/completions` (KIMI_MODEL prompt 合成) → usecase **`prompt-gen`**
- `generateIcon` → `/v1/images/generations` (DASHSCOPE 浮世绘生图) → usecase **`image-gen`**

无第二处 critique/反思 chat，仅这两处。

### 硬约束遵守
1. 只加 header，**body.model 不变**，零逻辑改动。未设 override 时行为 100% = 当前实际。
2. usecase 命名小写连字符，语义清晰，对齐 icon-forge 风格。
3. 测试真断言 header 发出（非只改注释）。

### 测试
- `test/llm-gateway.test.ts` 两处 URL+auth 不变量测试加 `x-llm-usecase` 断言
- `npx vitest run` → **7/7 pass**；`tsc --noEmit` clean

@Lynx 审。CF worker 部署由 Cindy 合并后做。

spec: SPEC-285 | task: T-486