### PR TITLE
fix: stop publishing production source maps

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "build": "tsc && vite build",
+    "build": "tsc && vite build && npm run check:dist",
+    "check:dist": "node scripts/assert-production-dist.mjs",
     "preview": "vite preview"
   },
   "dependencies": {

--- a/scripts/assert-production-dist.mjs
+++ b/scripts/assert-production-dist.mjs
@@ -1,0 +1,40 @@
+import { readdir, readFile } from 'node:fs/promises'
+import { extname, join, relative } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const dist = fileURLToPath(new URL('../dist/', import.meta.url))
+const files = []
+
+async function walk(directory) {
+  for (const entry of await readdir(directory, { withFileTypes: true })) {
+    const path = join(directory, entry.name)
+    if (entry.isDirectory()) await walk(path)
+    else files.push(path)
+  }
+}
+
+try {
+  await walk(dist)
+} catch (error) {
+  console.error(`Production dist is missing or unreadable: ${error.message}`)
+  process.exit(1)
+}
+
+const maps = files.filter((file) => extname(file) === '.map')
+const bundles = files.filter((file) => ['.js', '.css'].includes(extname(file)))
+const references = []
+
+for (const file of bundles) {
+  if ((await readFile(file, 'utf8')).includes('sourceMappingURL')) {
+    references.push(relative(dist, file))
+  }
+}
+
+if (bundles.length === 0 || maps.length > 0 || references.length > 0) {
+  if (bundles.length === 0) console.error('Production dist contains no JS or CSS bundles')
+  if (maps.length > 0) console.error(`Production dist contains source maps:\n${maps.join('\n')}`)
+  if (references.length > 0) console.error(`Production bundles expose sourceMappingURL:\n${references.join('\n')}`)
+  process.exit(1)
+}
+
+console.log(`Verified ${bundles.length} production JS/CSS bundles: no source maps or sourceMappingURL references`)

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -4,9 +4,9 @@ import react from '@vitejs/plugin-react'
 export default defineConfig({
   plugins: [react()],
   build: {
-    // SPEC-205: keep prod sourcemap so future i18n / debug recoveries don't
-    // have to rummage through minified bundles again.
-    sourcemap: true,
+    // Keep production source private. Vite's dev server still serves source
+    // modules directly, so local debugging ergonomics are unchanged.
+    sourcemap: false,
   },
   server: {
     proxy: {


### PR DESCRIPTION
Disable public production source maps while preserving Vite dev-server source debugging.

- production `sourcemap: false`
- build now fails if dist contains `.map` or `sourceMappingURL`
- generated JS/CSS hashes/content otherwise unchanged

Verification: `npm run build` passed; 2 bundles checked, zero maps/references.
