### PR TITLE
fix: preserve SSE reconnect on transport errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "dev": "vite",
     "build": "tsc && vite build && npm run check:dist",
     "check:dist": "node scripts/assert-production-dist.mjs",
+    "test": "node --experimental-strip-types --test test/*.test.mjs",
     "preview": "vite preview"
   },
   "dependencies": {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect, useCallback, useRef } from 'react'
 import { useT, toggleLang } from './i18n'
+import { parseSseBusinessError } from './sse-error'
 
 // --- Types ---
 
@@ -432,12 +433,13 @@ export default function App() {
     })
 
     es.addEventListener('error', (e) => {
-      try {
-        const data = JSON.parse((e as MessageEvent).data)
-        setError(data.message || t('err.generateFailed'))
-      } catch {
-        setError(t('err.connectionBroken'))
-      }
+      // `event: error` from the server is a MessageEvent. A native transport
+      // failure is a plain Event and must fall through to es.onerror so the
+      // reconnect path retains the task id and can retry.
+      const businessError = parseSseBusinessError(e)
+      if (!businessError) return
+
+      setError(businessError.message || t('err.generateFailed'))
       setPhase('error')
       setLoading(false)
       es.onerror = null

--- a/src/sse-error.ts
+++ b/src/sse-error.ts
@@ -1,0 +1,26 @@
+export interface SseBusinessError {
+  message?: string
+}
+
+/**
+ * EventSource uses the same `error` event name for two different things:
+ *
+ * - server-sent `event: error` messages arrive as MessageEvent instances;
+ * - native transport failures arrive as plain Event instances.
+ *
+ * Returning null for transport failures lets EventSource.onerror own reconnects.
+ */
+export function parseSseBusinessError(event: Event): SseBusinessError | null {
+  if (!(event instanceof MessageEvent)) return null
+
+  try {
+    const data: unknown = JSON.parse(event.data)
+    if (!data || typeof data !== 'object') return {}
+    const message = 'message' in data && typeof data.message === 'string'
+      ? data.message
+      : undefined
+    return { message }
+  } catch {
+    return {}
+  }
+}

--- a/test/sse-error.test.mjs
+++ b/test/sse-error.test.mjs
@@ -1,0 +1,20 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { parseSseBusinessError } from '../src/sse-error.ts'
+
+test('native EventSource errors remain available to the reconnect handler', () => {
+  assert.equal(parseSseBusinessError(new Event('error')), null)
+})
+
+test('server-sent error messages are classified as business errors', () => {
+  const event = new MessageEvent('error', {
+    data: JSON.stringify({ message: 'generation failed' }),
+  })
+
+  assert.deepEqual(parseSseBusinessError(event), { message: 'generation failed' })
+})
+
+test('malformed server error payloads stay business errors', () => {
+  const event = new MessageEvent('error', { data: 'not-json' })
+  assert.deepEqual(parseSseBusinessError(event), {})
+})


### PR DESCRIPTION
Closes #31

## What changed
- classify server-sent `event: error` messages separately from native EventSource transport errors
- let native errors reach the existing `onerror` reconnect path without clearing the task id
- add regression coverage for transport, business, and malformed business error events

## Verification
- `npm test` — 3/3 passing
- `npm run build` — TypeScript + Vite build passed; production dist check passed

## Process audit
Cindy's product-code commit guard blocked the initial commit. Rei is no longer present in the active OpenClaw configuration, so the change could not be delegated. Dale explicitly authorized proceeding and deployment in Discord DM at 2026-08-07 18:30 GMT+8; this commit used `--no-verify` under the guard's audited exception path.
