### PR TITLE
feat: reuse trusted session for Turnstile verification

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -49,25 +49,19 @@ const TEST_PARAM = _params.has('test') ? '?test' : ''
 // Cloudflare Turnstile site key (public, safe to ship in bundle).
 const TURNSTILE_SITE_KEY = '0x4AAAAAADCaJQDyyQeiqkiM'
 
-// Run a one-shot invisible Turnstile challenge; returns the token or throws.
-// The token is single-use — request a fresh one for every /api/generate call.
+// Managed Turnstile stays visually absent for low-risk users (`interaction-only`)
+// but has a real, clickable 300×65 host when Cloudflare asks for interaction.
 function getTurnstileToken(): Promise<string> {
   return new Promise((resolve, reject) => {
     // @ts-expect-error — turnstile is loaded via index.html <script>
     const ts = window.turnstile
-    if (!ts) {
-      reject(new Error('turnstile not loaded'))
-      return
-    }
-    // Turnstile invisible mode requires an actually-rendered container
-    // (display:none breaks the challenge). Use off-screen positioning with
-    // zero size + aria-hidden so it's invisible to users but live in layout.
-    const host = document.createElement('div')
-    host.setAttribute('aria-hidden', 'true')
-    host.style.cssText =
-      'position:fixed;bottom:0;right:0;width:0;height:0;overflow:hidden;pointer-events:none;opacity:0;'
-    document.body.appendChild(host)
+    if (!ts) { reject(new Error('turnstile not loaded')); return }
 
+    const host = document.createElement('div')
+    host.setAttribute('aria-label', '安全验证')
+    host.style.cssText =
+      'position:fixed;right:20px;bottom:20px;z-index:9999;width:300px;min-height:65px;pointer-events:auto;'
+    document.body.appendChild(host)
     let settled = false
     const done = (fn: () => void) => {
       if (settled) return
@@ -75,14 +69,12 @@ function getTurnstileToken(): Promise<string> {
       try { document.body.removeChild(host) } catch {}
       fn()
     }
-    // Hard safety timeout so the UI never hangs on 准备中 if Turnstile
-    // hangs silently (adblocker / network / script not yet loaded).
-    const timer = setTimeout(() => done(() => reject(new Error('turnstile timeout (10s)'))), 10_000)
-
+    const timer = setTimeout(() => done(() => reject(new Error('turnstile timeout'))), 60_000)
     try {
       ts.render(host, {
         sitekey: TURNSTILE_SITE_KEY,
-        size: 'invisible',
+        size: 'normal',
+        appearance: 'interaction-only',
         callback: (token: string) => { clearTimeout(timer); done(() => resolve(token)) },
         'error-callback': () => { clearTimeout(timer); done(() => reject(new Error('turnstile error'))) },
         'timeout-callback': () => { clearTimeout(timer); done(() => reject(new Error('turnstile timeout'))) },
@@ -92,6 +84,20 @@ function getTurnstileToken(): Promise<string> {
       done(() => reject(e as Error))
     }
   })
+}
+
+async function establishTrustedSession(): Promise<void> {
+  const turnstileToken = await getTurnstileToken()
+  const res = await fetch(`${API_BASE}/session`, {
+    method: 'POST',
+    credentials: 'include',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ turnstileToken }),
+  })
+  if (!res.ok) {
+    const data = await res.json().catch(() => ({})) as Partial<ErrorResponse>
+    throw new Error(data.message || '人机验证未通过，请重试')
+  }
 }
 
 // T-079 B2: polling cadence used by the visibilitychange fallback when SSE is
@@ -226,7 +232,7 @@ export default function App() {
 
   async function fetchQuota() {
     try {
-      const res = await fetch(`${API_BASE}/quota${TEST_PARAM}`)
+      const res = await fetch(`${API_BASE}/quota${TEST_PARAM}`, { credentials: 'include' })
       if (res.ok) {
         const data: QuotaResponse = await res.json()
         setRemaining(data.remaining)
@@ -511,23 +517,21 @@ export default function App() {
     cleanup()
 
     try {
-      let turnstileToken = ''
-      try {
-        turnstileToken = await getTurnstileToken()
-      } catch (e) {
-        // Soft-fail: if Turnstile can't be reached (adblocker, offline), we
-        // still attempt the call; worker will reject with 403 if it requires
-        // the token. This keeps the failure message clean.
-        console.warn('turnstile unavailable, calling without token:', e)
-      }
-
-      const res = await fetch(`${API_BASE}/generate${TEST_PARAM}`, {
+      const sendGenerate = () => fetch(`${API_BASE}/generate${TEST_PARAM}`, {
         method: 'POST',
+        credentials: 'include',
         headers: { 'Content-Type': 'application/json' },
-        // T-079 F3: include user-selected master in the body so worker
-        // skips its old "LLM picks 2 masters" step and uses this one.
-        body: JSON.stringify({ description: trimmed, master, turnstileToken }),
+        body: JSON.stringify({ description: trimmed, master }),
       })
+
+      let res = await sendGenerate()
+      if (res.status === 401 && !TEST_PARAM) {
+        const data = await res.clone().json().catch(() => ({})) as Partial<ErrorResponse>
+        if (data.error === 'verification_required') {
+          await establishTrustedSession()
+          res = await sendGenerate() // one retry only
+        }
+      }
 
       if (res.status === 429) {
         const data: ErrorResponse = await res.json()

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -73,6 +73,7 @@ interface QueueTask {
   taskId: string;
   description: string;
   ip: string;
+  sessionId?: string;
   isTestMode: boolean;
   testRemaining?: number;
   promptModel: string;
@@ -117,7 +118,8 @@ const DASHSCOPE_MODEL = "qwen-image-2.0-pro-2026-04-22";
 export const CHAT_PATH = "/v1/chat/completions";
 export const IMAGE_PATH = "/v1/images/generations";
 const CORS_HEADERS: Record<string, string> = {
-  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Origin": "https://ukiyo.openclawd.co",
+  "Access-Control-Allow-Credentials": "true",
   "Access-Control-Allow-Methods": "POST, GET, OPTIONS",
   "Access-Control-Allow-Headers": "Content-Type",
 };
@@ -367,6 +369,102 @@ function getClientIP(request: Request): string {
 function getTodayKey(ip: string): string {
   const today = new Date().toISOString().slice(0, 10);
   return `limit:${ip}:${today}`;
+}
+
+const SESSION_COOKIE = "trusted_session";
+const SESSION_CONTEXT = "trusted-session-v1";
+
+type TrustedSession = { sid: string; exp: number };
+
+function base64Url(bytes: Uint8Array): string {
+  let binary = "";
+  for (const byte of bytes) binary += String.fromCharCode(byte);
+  return btoa(binary).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/g, "");
+}
+
+function fromBase64Url(value: string): Uint8Array {
+  const normalized = value.replace(/-/g, "+").replace(/_/g, "/");
+  const binary = atob(normalized + "=".repeat((4 - normalized.length % 4) % 4));
+  return Uint8Array.from(binary, (c) => c.charCodeAt(0));
+}
+
+async function sessionKey(secret: string): Promise<CryptoKey> {
+  return crypto.subtle.importKey(
+    "raw", new TextEncoder().encode(secret), { name: "HMAC", hash: "SHA-256" }, false, ["sign", "verify"]
+  );
+}
+
+async function issueTrustedSession(secret: string): Promise<{ value: string; session: TrustedSession }> {
+  const now = Date.now();
+  const nextUtcDay = Date.UTC(new Date(now).getUTCFullYear(), new Date(now).getUTCMonth(), new Date(now).getUTCDate() + 1);
+  const session: TrustedSession = { sid: crypto.randomUUID(), exp: Math.min(now + 86_400_000, nextUtcDay) };
+  const payload = base64Url(new TextEncoder().encode(JSON.stringify(session)));
+  const message = new TextEncoder().encode(`${SESSION_CONTEXT}.${payload}`);
+  const signature = new Uint8Array(await crypto.subtle.sign("HMAC", await sessionKey(secret), message));
+  return { value: `${payload}.${base64Url(signature)}`, session };
+}
+
+async function verifyTrustedSession(request: Request, secret?: string): Promise<TrustedSession | null> {
+  if (!secret) return null;
+  const raw = request.headers.get("Cookie")?.split(";").map((v) => v.trim())
+    .find((v) => v.startsWith(`${SESSION_COOKIE}=`))?.slice(SESSION_COOKIE.length + 1);
+  if (!raw) return null;
+  const [payload, signature, extra] = raw.split(".");
+  if (!payload || !signature || extra) return null;
+  try {
+    const valid = await crypto.subtle.verify(
+      "HMAC", await sessionKey(secret), fromBase64Url(signature),
+      new TextEncoder().encode(`${SESSION_CONTEXT}.${payload}`)
+    );
+    if (!valid) return null;
+    const parsed = JSON.parse(new TextDecoder().decode(fromBase64Url(payload))) as TrustedSession;
+    if (!parsed.sid || !Number.isFinite(parsed.exp) || parsed.exp <= Date.now()) return null;
+    return parsed;
+  } catch {
+    return null;
+  }
+}
+
+function sessionLimitKey(sessionId: string): string {
+  const today = new Date().toISOString().slice(0, 10);
+  return `session-limit:${sessionId}:${today}`;
+}
+
+async function getCount(kv: KVNamespace, key: string): Promise<number> {
+  const raw = await kv.get(key);
+  return raw ? parseInt(raw, 10) || 0 : 0;
+}
+
+async function checkSessionLimit(kv: KVNamespace, sessionId: string): Promise<{ allowed: boolean; remaining: number }> {
+  const count = await getCount(kv, sessionLimitKey(sessionId));
+  return { allowed: count < DAILY_LIMIT, remaining: Math.max(0, DAILY_LIMIT - count) };
+}
+
+async function incrementSessionLimit(kv: KVNamespace, sessionId: string): Promise<number> {
+  const key = sessionLimitKey(sessionId);
+  const next = await getCount(kv, key) + 1;
+  await kv.put(key, String(next), { expirationTtl: 86400 });
+  return Math.max(0, DAILY_LIMIT - next);
+}
+
+async function handleSessionBootstrap(request: Request, env: Env): Promise<Response> {
+  let token = "";
+  try { token = String(((await request.json()) as { turnstileToken?: string }).turnstileToken || ""); }
+  catch { return jsonResponse({ error: "invalid_input", message: "无效的验证请求" }, 400); }
+  const ip = getClientIP(request);
+  if (!await verifyTurnstile(token, env, ip) || !env.TURNSTILE_SECRET) {
+    return jsonResponse({ error: "turnstile_failed", message: "人机验证未通过，请重试" }, 403);
+  }
+  const { value, session } = await issueTrustedSession(env.TURNSTILE_SECRET);
+  const maxAge = Math.max(1, Math.floor((session.exp - Date.now()) / 1000));
+  return new Response(JSON.stringify({ ok: true, expiresAt: session.exp }), {
+    status: 200,
+    headers: {
+      "Content-Type": "application/json",
+      "Set-Cookie": `${SESSION_COOKIE}=${value}; Max-Age=${maxAge}; Path=/api; HttpOnly; Secure; SameSite=Strict`,
+      ...CORS_HEADERS,
+    },
+  });
 }
 
 // --- Rate limiting (check only, no increment) ---
@@ -724,6 +822,7 @@ export class GenerationQueue {
       taskId: string;
       description: string;
       ip: string;
+      sessionId?: string;
       isTestMode: boolean;
       promptModel: string;
       master: StyleWord;  // T-079 F3: validated upstream in handleGenerate
@@ -765,6 +864,7 @@ export class GenerationQueue {
       taskId: body.taskId,
       description: body.description,
       ip: body.ip,
+      sessionId: body.sessionId,
       isTestMode: body.isTestMode,
       testRemaining,
       promptModel: body.promptModel || KIMI_MODEL,
@@ -985,7 +1085,10 @@ export class GenerationQueue {
         // Step 4: Increment rate limit (deferred billing)
         const remaining = task.isTestMode
           ? (task.testRemaining ?? 0)
-          : await incrementRateLimit(this.env.RATE_LIMIT, task.ip);
+          : Math.min(
+              await incrementRateLimit(this.env.RATE_LIMIT, task.ip),
+              task.sessionId ? await incrementSessionLimit(this.env.RATE_LIMIT, task.sessionId) : 0,
+            );
         task.remaining = remaining;
 
         // Complete
@@ -1178,23 +1281,21 @@ async function handleGenerate(
   const isTestMode = url.searchParams.has("test");
   const promptModel = KIMI_MODEL;
 
-  // Burst limit (short window) before daily quota to stop script floods.
+  let trustedSession: TrustedSession | null = null;
+  // Test mode keeps its separately capped test quota. Production generation
+  // requires a server-signed anonymous session, established once via Turnstile.
   if (!isTestMode) {
-    // Turnstile first (bot check) — only in non-test mode.
-    const ok = await verifyTurnstile(body.turnstileToken || "", env, ip);
-    if (!ok) {
+    trustedSession = await verifyTrustedSession(request, env.TURNSTILE_SECRET);
+    if (!trustedSession) {
       return jsonResponse(
-        { error: "turnstile_failed", message: "人机验证未通过，请刷新重试" },
-        403
+        { error: "verification_required", message: "需要完成一次安全验证" },
+        401
       );
     }
     const burst = await checkBurst(env.RATE_LIMIT, ip);
     if (!burst.allowed) {
       return jsonResponse(
-        {
-          error: "rate_limited_burst",
-          message: `请求太快，请 ${burst.retryAfter}s 后再试`,
-        },
+        { error: "rate_limited_burst", message: `请求太快，请 ${burst.retryAfter}s 后再试` },
         429
       );
     }
@@ -1214,6 +1315,16 @@ async function handleGenerate(
     }
   }
 
+  if (!isTestMode && trustedSession) {
+    const sessionQuota = await checkSessionLimit(env.RATE_LIMIT, trustedSession.sid);
+    if (!sessionQuota.allowed) {
+      return jsonResponse(
+        { error: "rate_limited", message: "内测中，每日限额已用完，请明天再来 🙂" },
+        429
+      );
+    }
+  }
+
   // Forward to Durable Object
   const taskId = generateTaskId();
   const doId = env.GENERATION_QUEUE.idFromName("singleton");
@@ -1223,7 +1334,7 @@ async function handleGenerate(
     new Request("https://do/enqueue", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ taskId, description, ip, isTestMode, promptModel, master }),
+      body: JSON.stringify({ taskId, description, ip, sessionId: trustedSession?.sid, isTestMode, promptModel, master }),
     })
   );
 
@@ -1393,6 +1504,13 @@ export default {
 
     if (request.method === "OPTIONS") {
       return new Response(null, { status: 204, headers: CORS_HEADERS });
+    }
+
+    if (path === "/api/session" && request.method === "POST") {
+      if (!isAllowedOrigin(request)) {
+        return jsonResponse({ error: "forbidden", message: "origin not allowed" }, 403);
+      }
+      return handleSessionBootstrap(request, env);
     }
 
     if (path === "/api/generate" && request.method === "POST") {


### PR DESCRIPTION
## Summary
- replace per-generation hidden Turnstile with a signed HttpOnly anonymous session
- keep IP quota + burst limit and add session-scoped quota
- use a visible Managed widget only when Cloudflare requires interaction
- use credentialed explicit-origin CORS

## Verification
- `npm run build`
- `npm run test` (3/3)
- `npm --prefix worker run typecheck`
- `npm --prefix worker test` (7/7)
- Cloudflare widget mode verified as `managed`

Closes #33
