### PR TITLE
fix: recover when Turnstile is content-blocked

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -69,7 +69,7 @@ function getTurnstileToken(): Promise<string> {
       try { document.body.removeChild(host) } catch {}
       fn()
     }
-    const timer = setTimeout(() => done(() => reject(new Error('turnstile timeout'))), 60_000)
+    const timer = setTimeout(() => done(() => reject(new Error('turnstile timeout'))), 12_000)
     try {
       ts.render(host, {
         sitekey: TURNSTILE_SITE_KEY,
@@ -86,17 +86,57 @@ function getTurnstileToken(): Promise<string> {
   })
 }
 
-async function establishTrustedSession(): Promise<void> {
-  const turnstileToken = await getTurnstileToken()
-  const res = await fetch(`${API_BASE}/session`, {
-    method: 'POST',
-    credentials: 'include',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ turnstileToken }),
+function leadingZeroBits(bytes: Uint8Array): number {
+  let bits = 0
+  for (const byte of bytes) {
+    if (byte === 0) { bits += 8; continue }
+    bits += Math.clz32(byte) - 24
+    break
+  }
+  return bits
+}
+
+async function solvePow(): Promise<{ powChallenge: string; powCounter: number }> {
+  const challengeRes = await fetch(`${API_BASE}/pow-challenge`, {
+    method: 'POST', credentials: 'include',
   })
+  if (!challengeRes.ok) throw new Error('安全验证暂时不可用')
+  const { challenge, difficulty } = await challengeRes.json() as { challenge: string; difficulty: number }
+  const encoder = new TextEncoder()
+  // Small parallel batches keep the UI responsive while making scripted abuse costly.
+  for (let base = 0; base <= 4_194_304; base += 128) {
+    const digests = await Promise.all(Array.from({ length: 128 }, (_, i) =>
+      crypto.subtle.digest('SHA-256', encoder.encode(`${challenge}:${base + i}`))))
+    const found = digests.findIndex((digest) => leadingZeroBits(new Uint8Array(digest)) >= difficulty)
+    if (found >= 0) return { powChallenge: challenge, powCounter: base + found }
+    if (base % 2048 === 0) await new Promise<void>((resolve) => setTimeout(resolve, 0))
+  }
+  throw new Error('安全验证计算超时，请重试')
+}
+
+async function postSession(body: Record<string, unknown>): Promise<Response> {
+  return fetch(`${API_BASE}/session`, {
+    method: 'POST', credentials: 'include',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  })
+}
+
+async function establishTrustedSession(): Promise<void> {
+  let res: Response | null = null
+  try {
+    const turnstileToken = await getTurnstileToken()
+    res = await postSession({ turnstileToken })
+    if (res.ok) return
+  } catch (error) {
+    console.warn('Turnstile unavailable; using first-party verification fallback', error)
+  }
+
+  const proof = await solvePow()
+  res = await postSession(proof)
   if (!res.ok) {
     const data = await res.json().catch(() => ({})) as Partial<ErrorResponse>
-    throw new Error(data.message || '人机验证未通过，请重试')
+    throw new Error(data.message || '安全验证未通过，请重试')
   }
 }
 

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -373,6 +373,9 @@ function getTodayKey(ip: string): string {
 
 const SESSION_COOKIE = "trusted_session";
 const SESSION_CONTEXT = "trusted-session-v1";
+const POW_CONTEXT = "pow-challenge-v1";
+const POW_DIFFICULTY = 18;
+const POW_TTL_MS = 2 * 60_000;
 
 type TrustedSession = { sid: string; exp: number };
 
@@ -447,13 +450,75 @@ async function incrementSessionLimit(kv: KVNamespace, sessionId: string): Promis
   return Math.max(0, DAILY_LIMIT - next);
 }
 
+type PowPayload = { nonce: string; exp: number; ipTag: string };
+
+async function hmacValue(secret: string, context: string, payload: string): Promise<string> {
+  const bytes = new Uint8Array(await crypto.subtle.sign(
+    "HMAC", await sessionKey(secret), new TextEncoder().encode(`${context}.${payload}`)
+  ));
+  return base64Url(bytes);
+}
+
+async function ipTag(secret: string, ip: string): Promise<string> {
+  return (await hmacValue(secret, "pow-ip-v1", ip)).slice(0, 16);
+}
+
+async function issuePowChallenge(request: Request, env: Env): Promise<Response> {
+  if (!env.TURNSTILE_SECRET) return jsonResponse({ error: "verification_unavailable" }, 503);
+  const payload: PowPayload = {
+    nonce: crypto.randomUUID(),
+    exp: Date.now() + POW_TTL_MS,
+    ipTag: await ipTag(env.TURNSTILE_SECRET, getClientIP(request)),
+  };
+  const encoded = base64Url(new TextEncoder().encode(JSON.stringify(payload)));
+  const signature = await hmacValue(env.TURNSTILE_SECRET, POW_CONTEXT, encoded);
+  return jsonResponse({ challenge: `${encoded}.${signature}`, difficulty: POW_DIFFICULTY }, 200);
+}
+
+function hasLeadingZeroBits(bytes: Uint8Array, bits: number): boolean {
+  const full = Math.floor(bits / 8);
+  for (let i = 0; i < full; i++) if (bytes[i] !== 0) return false;
+  const remainder = bits % 8;
+  return remainder === 0 || (bytes[full] & (0xff << (8 - remainder))) === 0;
+}
+
+async function verifyPow(
+  request: Request, env: Env, challenge: string, counter: number
+): Promise<boolean> {
+  if (!env.TURNSTILE_SECRET || !Number.isSafeInteger(counter) || counter < 0 || counter > 4_194_304) return false;
+  const [encoded, signature, extra] = challenge.split(".");
+  if (!encoded || !signature || extra) return false;
+  const expected = await hmacValue(env.TURNSTILE_SECRET, POW_CONTEXT, encoded);
+  if (expected.length !== signature.length) return false;
+  let different = 0;
+  for (let i = 0; i < expected.length; i++) different |= expected.charCodeAt(i) ^ signature.charCodeAt(i);
+  if (different !== 0) return false;
+  try {
+    const payload = JSON.parse(new TextDecoder().decode(fromBase64Url(encoded))) as PowPayload;
+    if (!payload.nonce || payload.exp < Date.now() || payload.exp > Date.now() + POW_TTL_MS + 5_000) return false;
+    if (payload.ipTag !== await ipTag(env.TURNSTILE_SECRET, getClientIP(request))) return false;
+    const replayKey = `pow-used:${payload.nonce}`;
+    if (await env.RATE_LIMIT.get(replayKey)) return false;
+    const digest = new Uint8Array(await crypto.subtle.digest(
+      "SHA-256", new TextEncoder().encode(`${challenge}:${counter}`)
+    ));
+    if (!hasLeadingZeroBits(digest, POW_DIFFICULTY)) return false;
+    await env.RATE_LIMIT.put(replayKey, "1", { expirationTtl: 180 });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 async function handleSessionBootstrap(request: Request, env: Env): Promise<Response> {
-  let token = "";
-  try { token = String(((await request.json()) as { turnstileToken?: string }).turnstileToken || ""); }
+  let body: { turnstileToken?: string; powChallenge?: string; powCounter?: number };
+  try { body = await request.json() as typeof body; }
   catch { return jsonResponse({ error: "invalid_input", message: "无效的验证请求" }, 400); }
   const ip = getClientIP(request);
-  if (!await verifyTurnstile(token, env, ip) || !env.TURNSTILE_SECRET) {
-    return jsonResponse({ error: "turnstile_failed", message: "人机验证未通过，请重试" }, 403);
+  const turnstileOk = !!body.turnstileToken && await verifyTurnstile(body.turnstileToken, env, ip);
+  const powOk = !!body.powChallenge && await verifyPow(request, env, body.powChallenge, Number(body.powCounter));
+  if ((!turnstileOk && !powOk) || !env.TURNSTILE_SECRET) {
+    return jsonResponse({ error: "verification_failed", message: "安全验证未通过，请重试" }, 403);
   }
   const { value, session } = await issueTrustedSession(env.TURNSTILE_SECRET);
   const maxAge = Math.max(1, Math.floor((session.exp - Date.now()) / 1000));
@@ -1504,6 +1569,11 @@ export default {
 
     if (request.method === "OPTIONS") {
       return new Response(null, { status: 204, headers: CORS_HEADERS });
+    }
+
+    if (path === "/api/pow-challenge" && request.method === "POST") {
+      if (!isAllowedOrigin(request)) return jsonResponse({ error: "forbidden" }, 403);
+      return issuePowChallenge(request, env);
     }
 
     if (path === "/api/session" && request.method === "POST") {


### PR DESCRIPTION
## Root cause
Content blockers can block the third-party Turnstile frame/script. The trusted-session bootstrap then never completes and `/api/generate` correctly returns 401, but the user has no recovery path.

## Fix
- retain Turnstile as the preferred path
- automatically fall back to a first-party, signed, 2-minute proof-of-work challenge
- bind challenge to a coarse server-authenticated IP tag, enforce one-time use in KV, and cap the counter
- issue the same HttpOnly trusted session only after proof verification
- apply existing IP + session quota and burst limits unchanged

## Verification
- frontend build + tests 3/3
- worker typecheck + tests 7/7
- content-blocker path uses only first-party API endpoints

Follow-up to #33 / PR #34.
